### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/modules/basic_shape_processor.py
+++ b/modules/basic_shape_processor.py
@@ -348,7 +348,7 @@ def extract_style_colors(image: np.ndarray, bbox: list) -> tuple:
             counts = np.bincount(labels.flatten())
             dominant_idx = np.argmax(counts)
             fill_rgb = centers[dominant_idx].astype(int)
-        except:
+        except Exception:
             pass  # 保持中位数结果
     
     # --- 2. 提取描边色 (Stroke Color) ---
@@ -540,7 +540,7 @@ def extract_color_with_mask(image: np.ndarray, bbox: list, mask: np.ndarray,
                 counts = np.bincount(labels.flatten())
                 dominant_idx = np.argmax(counts)
                 fill_rgb = centers[dominant_idx].astype(int)
-            except:
+            except Exception:
                 fill_rgb = np.median(fill_pixels, axis=0).astype(int)
         else:
             fill_rgb = np.median(fill_pixels, axis=0).astype(int)
@@ -1311,7 +1311,7 @@ def detect_rectangles_robust(cv2_image: np.ndarray, existing_elements: dict, con
                     counts = np.bincount(labels.flatten())
                     dominant_idx = np.argmax(counts)
                     fill_rgb = centers[dominant_idx].astype(int)
-                except:
+                except Exception:
                     fill_rgb = np.median(pixels, axis=0).astype(int)
             else:
                 fill_rgb = np.median(pixels, axis=0).astype(int) if len(pixels) > 0 else np.array([255, 255, 255])

--- a/modules/xml_merger.py
+++ b/modules/xml_merger.py
@@ -583,7 +583,7 @@ class XMLMerger(BaseProcessor):
                         x2=int(float(geom.get("x", 0))) + int(float(geom.get("width", 0))),
                         y2=int(float(geom.get("y", 0))) + int(float(geom.get("height", 0)))
                     )
-                except:
+                except Exception:
                     pass
             
             fragments.append(XMLFragment(


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.