### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,4 +402,4 @@ This project is open-source under the [Apache License 2.0](LICENSE), allowing co
 
 🌟 If this project helps you, please star it to show your support!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bit-datalab/edit-banana&type=date&legend=top-left)](https://www.star-history.com/#bit-datalab/edit-banana&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bit-datalab/edit-banana&type=date&legend=top-left)](https://star-history.dera.page/#bit-datalab/edit-banana&type=date&legend=top-left)

--- a/README_CN.md
+++ b/README_CN.md
@@ -387,4 +387,4 @@ python main.py -i input/test_diagram.png
 
 🌟 如果这个项目对你有帮助，请给个 Star 来支持我们！
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bit-datalab/edit-banana&type=date&legend=top-left)](https://www.star-history.com/#bit-datalab/edit-banana&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bit-datalab/edit-banana&type=date&legend=top-left)](https://star-history.dera.page/#bit-datalab/edit-banana&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the READMEs is currently broken because its provider depends on the GitHub stargazer API, which is subject to restrictions. This change points the chart to a working provider that uses an alternative data source and requires no API token, so the chart renders reliably again.

Applies the fix to both README.md and README_CN.md.